### PR TITLE
Struct len edge case

### DIFF
--- a/scripts/compile_report.py
+++ b/scripts/compile_report.py
@@ -40,7 +40,7 @@ class Report:
             and any([re.findall(r, self.lines[1]) for r in match_rules])
         )
 
-    def get_struct_len_definition(self) -> Tuple[str, str, str]:
+    def get_struct_len_definition(self) -> Tuple[str, str]:
         assert self.struct_len_undefined()
         match_rules = [
             ".*\((.*)\) ?malloc\(.*\)",

--- a/scripts/replace_input.py
+++ b/scripts/replace_input.py
@@ -61,7 +61,10 @@ def replace_line(line: str) -> str:
         line = line.replace("null", "nullptr")
     if "Null" in line:
         line = line.replace("Null", "nullptr")
-    if "scanf" in line:
+    if "scanf" in line and "sscanf" not in line:
+        # NOTE if there is any case that scanf and sscanf in same line,
+        # add that file to format list
+        
         # check if no args, like scanf("\n");
         if line[line.find("(") + 1 : line.find(")")].split('"')[-1] == "":
             return line


### PR DESCRIPTION
match rule for `calloc` and `malloc(num * LEN)`